### PR TITLE
Image pull secret not needed in prod

### DIFF
--- a/infra/cd/prod/deployment.yml
+++ b/infra/cd/prod/deployment.yml
@@ -44,8 +44,6 @@ spec:
         runAsNonRoot: true
         runAsUser: 10014
         runAsGroup: 10015
-      imagePullSecrets:
-        - name: tech-checkin-registry-secret
       containers:
         - image: harbor.pscp-css.support/library/tech-checkin:0.0.31
           name: tech-checkin


### PR DESCRIPTION
We don't need an image pull secret for harbor because we're getting the image from a public repo of harbor - our "library" project in harbor