### PR TITLE
Fix noisy log

### DIFF
--- a/src/CheckinAPI.py
+++ b/src/CheckinAPI.py
@@ -98,6 +98,9 @@ class Form(BaseModel):
 @checkin.post('/forms/submit', dependencies=[Depends(authorize)], tags=['Forms'])
 def submit_form(form: Form):
     logger.debug(form)
+    if form.work_market_num == '':
+        logger.error('Form submission is missing Work Market #.')
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail='Work Market # is required.')
     logger.info(f'Form submitted for {form.work_market_num}')
     report = smartsheet_controller.get_report(SMARTSHEET_REPORT_ID, geolocator)  # get sheet updates
     #take above parameters and either correct row in smartsheet and/or @ person in resposible collumn for correction to be made

--- a/src/alt_smartsheet.py
+++ b/src/alt_smartsheet.py
@@ -191,7 +191,6 @@ class AllTrackerSheet(AltSheet):
             except Exception as e:
                 raise ValueError(f"Work market number ran into an uncaught exception case: {e}") from e
         except TypeError:
-            logger.warning(f'Work market number is None or cannot be parsed at row #{row.row_number}')
             return ''
         return str(result)
 


### PR DESCRIPTION
When a form is submitted, it cycles through all rows until it finds a matching ID. This caused a lot of noise since it warned on empty logs. This is also a bug since the form shouldn't match on empty strings. The following commits solves this by requiring non-empty ID and removed the warning log.